### PR TITLE
different clone mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ const cliProgress = require('cli-progress');
       }
     } else {
       console.log(`Cloning ${repoName}`)
-      const stdout = await cmdAsync(`git clone ${repo} ${repoPath}`).catch(
+      const stdout = await cmdAsync(`git clone --mirror ${repo} ${repoPath}.git`).catch(
         console.log
       )
     }


### PR DESCRIPTION
It should do 'git clone --mirror' for a complete backup of all remote branches, not only a 'master'.